### PR TITLE
Issue #4: Facilitating link-ignoring from some social links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,7 @@ people:
       url: http://twitter.com/Jon_E_Mike
     - title: facebook
       url: http://www.facebook.com/jonmichael.d.brown
+      ignore: true
 
 # Social networks usernames (many more available: google-plus, flickr, dribbble, pinterest, instagram, tumblr, linkedin, etc.)
 social:

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -15,7 +15,7 @@
                         <p class="text-muted">{{ member.position }}</p>
                         <ul class="list-inline social-buttons">
                             {% for network in member.social %}
-                            <li><a href="{{ network.url }}"><i class="fa fa-{{ network.title }}"></i></a>
+                            <li><a {% if network.ignore %} data-proofer-ignore {% endif %} href="{{ network.url }}"><i class="fa fa-{{ network.title }}"></i></a>
                             {% endfor %}
 
                         </ul>


### PR DESCRIPTION
Since Jon-Michae's Facebook page is private, it keeps failing in
CI. Here, we're able to specify whether or not a given social link
should be ignored from `htmlproof` and provides the `data-proofer-ignore`
attribute to those links.

Signed-off-by: Elliot Voris elliot@voris.me
