### PR TITLE
LOVEtheLOU should be spelled the same everywhere

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ color:
 
 # Team names, titles and social links
 people:
-- name: Love the Lou
+- name: LOVEtheLOU
   pic: 1
   position: Service
   social:


### PR DESCRIPTION
I think that we have gotten this figured out in all the other places,
but this one got overlooked it seems.

Signed-off-by: Elliot Voris elliot@voris.me
